### PR TITLE
Replace `matches` with `hasAttribute`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,12 @@
 {
   "rules": {
-    "strict": 0,
-    "no-console": 0
+    "no-console": 0,
+    "semi": 2,
+    "strict": 0
   },
   "extends": "eslint:recommended",
   "env": {
     "browser": true,
-    "node": true,
+    "node": true
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,25 +2,12 @@
  * getElements
  * Return an array of elements, or an empty array;
  * @param  {Element} node - an element to scope the query to
- * @param  {String} selector
+ * @param  {String} attr
  * @return {Array}
  */
 
-function getElements (node, selector) {
-  return Array.prototype.slice.call(node.querySelectorAll(selector))
-}
-
-/**
- * matches
- * Return a boolean if DOM element matches a given selector.
- * @param  {Element el
- * @param  {String} selector
- * @return {Boolean}
- */
-
-function matches (el, selector) {
-  var matches = el.matches || el.msmatches;
-  return matches.call(el, selector);
+function getElements(node, attr) {
+  return Array.prototype.slice.call(node.querySelectorAll("[" + attr + "]"));
 }
 
 /**
@@ -30,7 +17,7 @@ function matches (el, selector) {
  * @return {String} str
  */
 
-function dasherize (str) {
+function dasherize(str) {
   var pattern = /([a-z0-9])([A-Z])/g;
   return str.replace(pattern, "$1-$2").toLowerCase();
 }
@@ -43,7 +30,7 @@ function dasherize (str) {
  * @return {String} value
  */
 
-function parseProps (value) {
+function parseProps(value) {
   var pattern = /^{/;
   if (pattern.test(value)) {
     value = JSON.parse(value);
@@ -56,15 +43,15 @@ function parseProps (value) {
  * Get an array of elements for a node.
  * return elements
  * @param  {Element} node
- * @param  {String} selector
+ * @param  {String} attr
  * @param  {Boolean} includeScope
  * @return {Array}
  */
 
-function checkElement(node, selector, includeScope) {
-  var elements = getElements(node, selector);
+function checkElement(node, attr, includeScope) {
+  var elements = getElements(node, attr);
 
-  if (includeScope && matches(node, selector)) {
+  if (includeScope && node.hasAttribute(attr)) {
     elements.push(node);
   }
 
@@ -76,12 +63,12 @@ function checkElement(node, selector, includeScope) {
  * Call the associated function for this specific view
  * Passing in the element and the value of the data attribute
  * @param  {Function} viewFunction
- * @param  {dashView} dashView - dasherized view name: my-bar-chart
+ * @param  {String} viewAttr - data view attribute name: data-view-my-bar-chart
  * @param  {Element} el
  */
 
-function callViewFunction(viewFunction, dashView, el) {
-  viewFunction.call(this, el, parseProps(el.getAttribute("data-view-" + dashView)));
+function callViewFunction(viewFunction, viewAttr, el) {
+  viewFunction.call(this, el, parseProps(el.getAttribute(viewAttr)));
 }
 
 /**
@@ -97,32 +84,32 @@ function callViewFunction(viewFunction, dashView, el) {
 
 function execute(views, scope, includeScope) {
 
-  for(var view in views) {
+  for (var view in views) {
     var dashView = dasherize(view);
-    var selector = "[data-view-" + dashView + "]";
+    var viewAttr = "data-view-" + dashView;
     var elements = [];
 
     if (scope) {
       if (scope.length) {
         Array.prototype.forEach.call(scope, function (node) {
-          var nodes = checkElement(node, selector, includeScope);
+          var nodes = checkElement(node, viewAttr, includeScope);
           elements = elements.concat(nodes);
         });
       } else {
-        var nodes = checkElement(scope, selector, includeScope);
+        var nodes = checkElement(scope, viewAttr, includeScope);
         elements = elements.concat(nodes);
       }
     } else {
-      elements = getElements(document, selector);
+      elements = getElements(document, viewAttr);
     }
 
     // for each value in `elements`, call `callViewFunction`
     Array.prototype.forEach.call(elements, function (element) {
-      callViewFunction(views[view], dashView, element);
+      callViewFunction(views[view], viewAttr, element);
     });
   }
 }
 
 module.exports = {
   execute: execute
-}
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 var test = require("tape");
 var viewLoader = require("../");


### PR DESCRIPTION
Determine whether to include the scoped element by looking for the `data-view-<dashed-view>` attribute with `hasAttribute` rather than by trying to match the `[data-view-<dashed-view>]` selector (which has poor cross-browser support).

Along the way, fix some missing semi-colons and configure ESLint to report them.